### PR TITLE
Change default project root to ~/.sproutee

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Display all existing worktrees with branch and commit information.
 sproutee list
 # Output:
 # Found 2 worktree(s):
-#   1. /path/to/repo/.git/sproutee-worktrees/feature_20241212_143022 (branch: feature-auth) [a1b2c3d4]
-#   2. /path/to/repo/.git/sproutee-worktrees/bugfix_20241212_144055 (branch: bugfix-login) [e5f6g7h8]
+#   1. ~/.sproutee/my-project/feature_20241212_143022 (branch: feature-auth) [a1b2c3d4]
+#   2. ~/.sproutee/my-project/bugfix_20241212_144055 (branch: bugfix-login) [e5f6g7h8]
 ```
 
 ### `sproutee clean`
@@ -204,14 +204,16 @@ Sproutee organizes worktrees in a clean, predictable structure:
 ```
 your-repo/
 ├── .git/
-│   ├── sproutee-worktrees/          # Sproutee worktrees (actual code)
-│   │   ├── feature_20241212_143022/
-│   │   └── bugfix_20241212_144055/
 │   └── worktrees/                   # Git metadata (managed by Git)
 │       ├── feature_20241212_143022/
 │       └── bugfix_20241212_144055/
 ├── sproutee.json                    # Configuration file
 └── ...                             # Your project files
+
+~/.sproutee/                         # Sproutee home directory
+└── your-repo/                       # Project-specific worktrees
+    ├── feature_20241212_143022/     # Actual worktree code
+    └── bugfix_20241212_144055/      # Actual worktree code
 ```
 
 ## Editor Integration

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	WorktreeDir = ".git/sproutee-worktrees"
+	SprouteeDir = ".sproutee"
 )
 
 type Manager struct {
@@ -68,8 +68,18 @@ func (m *Manager) GenerateWorktreeDirName(name string) (string, error) {
 	return fmt.Sprintf("%s_%s", name, timestamp), nil
 }
 
+func (m *Manager) getProjectName() string {
+	return filepath.Base(m.RepoRoot)
+}
+
 func (m *Manager) GetWorktreeBasePath() string {
-	return filepath.Join(m.RepoRoot, WorktreeDir)
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(m.RepoRoot, SprouteeDir)
+	}
+
+	projectName := m.getProjectName()
+	return filepath.Join(homeDir, SprouteeDir, projectName)
 }
 
 func (m *Manager) branchExists(branch string) bool {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -87,15 +87,41 @@ func TestManagerGenerateWorktreeDirName(t *testing.T) {
 	}
 }
 
+func TestManagerGetProjectName(t *testing.T) {
+	tests := []struct {
+		repoRoot     string
+		expectedName string
+	}{
+		{"/test/repo", "repo"},
+		{"/path/to/my-project", "my-project"},
+		{"/home/user/code/sproutee", "sproutee"},
+		{filepath.Join("C:", "Users", "user", "code", "my-app"), "my-app"},
+	}
+
+	for _, tt := range tests {
+		manager := &Manager{RepoRoot: tt.repoRoot}
+		projectName := manager.getProjectName()
+
+		if projectName != tt.expectedName {
+			t.Errorf("getProjectName() for %s = %v, want %v", tt.repoRoot, projectName, tt.expectedName)
+		}
+	}
+}
+
 func TestManagerGetWorktreeBasePath(t *testing.T) {
 	repoRoot := "/test/repo"
 	manager := &Manager{RepoRoot: repoRoot}
 
 	basePath := manager.GetWorktreeBasePath()
-	expected := filepath.Join(repoRoot, WorktreeDir)
 
-	if basePath != expected {
-		t.Errorf("GetWorktreeBasePath() = %v, want %v", basePath, expected)
+	// Should contain home directory and project name
+	if !strings.Contains(basePath, SprouteeDir) {
+		t.Errorf("GetWorktreeBasePath() should contain %s, got %v", SprouteeDir, basePath)
+	}
+
+	// Should contain project name (repo)
+	if !strings.Contains(basePath, "repo") {
+		t.Errorf("GetWorktreeBasePath() should contain project name 'repo', got %v", basePath)
 	}
 }
 


### PR DESCRIPTION
Hi, thanks for working this great project!

I'd like to introduce this fix that changes sproutee's default worktree root from each project's `.git` to `~/.sproutee`.

Since the package manager behaves unexpectedly when the worktree is into .git directory. I want to avoid this behavior. 

All changes are below 👇 

- Update worktree directory from .git/sproutee-worktrees to ~/.sproutee/{project-name}/
- Add getProjectName() method to extract project name from repository root
- Update GetWorktreeBasePath() to use home directory with project-specific subdirectory
- Update README.md to reflect new directory structure and examples
- Fix tests to work with new directory structure and add cross-platform path handling
