### PR TITLE
Add support for multiple init scripts in array format

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Sproutee streamlines your Git workflow by automating worktree creation and intel
 - 📁 **Smart File Copying**: Automatically copies configured files to new worktrees
 - 🎯 **Multi-Editor Support**: Launch Cursor, VS Code, Xcode, or Android Studio automatically with custom directory targeting
 - ⚙️ **Flexible Configuration**: JSON-based configuration for file management
+- 🔧 **Init Script Execution**: Run custom initialization scripts after worktree creation
 - 🧹 **Safe Cleanup**: Interactive worktree cleanup with uncommitted change detection
 - 🔍 **Status Monitoring**: Track worktree status and changes
 - 🛡️ **Cross-Platform**: Works on macOS, Windows, and Linux
@@ -147,6 +148,13 @@ Sproutee searches for `sproutee.json` in the following order:
 1. Current directory
 2. Parent directories (up to repository root)
 
+### Configuration Options
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `copy_files` | `string[]` | Yes | Array of file paths to copy to new worktrees |
+| `init_scripts` | `string[]` | No | Array of commands to execute after worktree creation |
+
 ### Configuration Format
 
 ```json
@@ -159,7 +167,8 @@ Sproutee searches for `sproutee.json` in the following order:
     "yarn.lock",
     "Makefile",
     ".vscode/settings.json"
-  ]
+  ],
+  "init_scripts": ["npm install", "npm run build"]
 }
 ```
 
@@ -174,7 +183,8 @@ Sproutee searches for `sproutee.json` in the following order:
     "package-lock.json",
     "yarn.lock",
     ".nvmrc"
-  ]
+  ],
+  "init_scripts": ["npm install", "npm run build"]
 }
 ```
 
@@ -186,11 +196,25 @@ Sproutee searches for `sproutee.json` in the following order:
     "docker-compose.yml",
     "Makefile",
     ".tool-versions"
-  ]
+  ],
+  "init_scripts": ["go mod download"]
 }
 ```
 
-**Empty Configuration (no file copying):**
+**Python Project:**
+```json
+{
+  "copy_files": [
+    ".env",
+    "requirements.txt",
+    "poetry.lock",
+    ".python-version"
+  ],
+  "init_scripts": ["pip install -r requirements.txt"]
+}
+```
+
+**Empty Configuration (no file copying or init scripts):**
 ```json
 {
   "copy_files": []
@@ -261,13 +285,14 @@ sproutee create feature --cursor
 cd my-project
 sproutee config init
 
-# 2. Edit sproutee.json to include necessary files
+# 2. Edit sproutee.json to include necessary files and init scripts
 echo '{
   "copy_files": [
     ".env",
     "docker-compose.yml",
     "package-lock.json"
-  ]
+  ],
+  "init_scripts": ["npm install", "npm run build"]
 }' > sproutee.json
 
 # 3. Create feature worktree

--- a/cmd/sproutee/main.go
+++ b/cmd/sproutee/main.go
@@ -25,7 +25,7 @@ const (
 var rootCmd = &cobra.Command{
 	Use:   "sproutee",
 	Short: "A CLI tool for managing Git worktrees efficiently",
-	Long: `Sproutee is a CLI tool that automates worktree creation and 
+	Long: `Sproutee is a CLI tool that automates worktree creation and
 copies specified files to new worktrees based on configuration.
 
 It helps manage multiple branches efficiently by creating worktrees
@@ -39,8 +39,8 @@ in .git/sproutee-worktrees/ directory and automatically copying configured files
 var createCmd = &cobra.Command{
 	Use:   "create <name>",
 	Short: "Create a new worktree with file copying",
-	Long: `Create a new Git worktree with the specified name. The name will be used 
-as both the worktree directory name and the branch name. Files specified in the 
+	Long: `Create a new Git worktree with the specified name. The name will be used
+as both the worktree directory name and the branch name. Files specified in the
 configuration will be automatically copied to the new worktree.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -479,7 +479,7 @@ func runInitScript(script, workingDir string) error {
 	} else {
 		cmd = exec.Command("sh", "-c", script)
 	}
-	
+
 	cmd.Dir = workingDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/sproutee/main.go
+++ b/cmd/sproutee/main.go
@@ -96,6 +96,21 @@ configuration will be automatically copied to the new worktree.`,
 			}
 		}
 
+		// Execute init scripts if configured
+		cfg, err := config.LoadConfigFromCurrentDir()
+		if err == nil && len(cfg.InitScripts) > 0 {
+			fmt.Printf("\n🔧 Running %d init script(s)...\n", len(cfg.InitScripts))
+			for i, script := range cfg.InitScripts {
+				fmt.Printf("  [%d/%d] %s\n", i+1, len(cfg.InitScripts), script)
+				if err := runInitScript(script, worktreePath); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: Failed to run init script %d: %v\n", i+1, err)
+				} else {
+					fmt.Printf("  ✅ Script %d completed successfully\n", i+1)
+				}
+			}
+			fmt.Println("🎉 All init scripts completed")
+		}
+
 		// Auto-open editor if any flag is set
 		if openCursor {
 			fmt.Println("\n🚀 Opening Cursor...")
@@ -185,6 +200,15 @@ var configListCmd = &cobra.Command{
 		fmt.Printf("Files to copy: %d\n", len(cfg.CopyFiles))
 		for i, file := range cfg.CopyFiles {
 			fmt.Printf("  %d. %s\n", i+1, file)
+		}
+
+		if len(cfg.InitScripts) > 0 {
+			fmt.Printf("Init scripts: %d\n", len(cfg.InitScripts))
+			for i, script := range cfg.InitScripts {
+				fmt.Printf("  %d. %s\n", i+1, script)
+			}
+		} else {
+			fmt.Println("Init scripts: (not configured)")
 		}
 	},
 }
@@ -439,6 +463,28 @@ func openInEditor(path, editor string) error {
 	}
 
 	return cmd.Start()
+}
+
+// runInitScript executes the specified script in the worktree directory
+func runInitScript(script, workingDir string) error {
+	if strings.TrimSpace(script) == "" {
+		return fmt.Errorf("empty script command")
+	}
+
+	// Use shell to execute the entire command string
+	// This allows for complex commands with pipes, && operators, etc.
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/C", script)
+	} else {
+		cmd = exec.Command("sh", "-c", script)
+	}
+	
+	cmd.Dir = workingDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
 }
 
 func init() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,8 @@ import (
 const ConfigFileName = "sproutee.json"
 
 type Config struct {
-	CopyFiles []string `json:"copy_files"`
+	CopyFiles   []string `json:"copy_files"`
+	InitScripts []string `json:"init_scripts,omitempty"`
 }
 
 func DefaultConfig() *Config {


### PR DESCRIPTION
I'd like to introduce `init_scripts` field

- Change init_script from string to init_scripts array in config
- Support executing multiple scripts sequentially after worktree creation
- Use shell execution (sh -c/cmd /C) to support complex commands with &&, pipes, etc.
- Update README with new configuration format and examples
- Display progress for each script execution with status indicators

🤖 Generated with [Claude Code](https://claude.ai/code)